### PR TITLE
Do not set DEBUG in hooks

### DIFF
--- a/django_plugin_django_debug_toolbar/__init__.py
+++ b/django_plugin_django_debug_toolbar/__init__.py
@@ -21,9 +21,6 @@ def settings(current_settings):
 
     current_settings.setdefault("INTERNAL_IPS", []).append("127.0.0.1")
 
-    # Debug Toolbar will only display when DEBUG = True
-    current_settings["DEBUG"] = True
-
     current_settings["MIDDLEWARE"] = inject_middleware(current_settings["MIDDLEWARE"])
 
 

--- a/tests/test_project/settings.py
+++ b/tests/test_project/settings.py
@@ -1,6 +1,7 @@
 import djp
 
 SECRET_KEY = "django-insecure-test-key"
+DEBUG = True
 
 INSTALLED_APPS = []
 


### PR DESCRIPTION
Addresses #4 

Unit tests pass, ~but I want to do a bit of manual testing to see that the issues are really fixed (`DEBUG` can be overridden easily, for example).~ and I manually tested that `DEBUG` can now be set in the settings module to turn on/off the debug toolbar.